### PR TITLE
Add camera movement and cube rotation functionality using keyboard and mouse inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To run the program, execute the following command in the terminal:
 ```
 This will launch the CubeSolver program, and you will be able to move the cube by pressing keys on your keyboard.
 
-## Keyboard Controls
-CubeSolver allows you to manipulate the Rubik's Cube using the following keys:
+## Keyboard and Mouse Controls
+CubeSolver allows you to manipulate the Rubik's Cube using the following controls:
 
 - `U`: rotate the upper layer clockwise
 - `u`: rotate the upper layer counter-clockwise
@@ -48,6 +48,13 @@ CubeSolver allows you to manipulate the Rubik's Cube using the following keys:
 - `B`: rotate the back layer clockwise
 - `b`: rotate the back layer counter-clockwise
 - `1`: return the cube to its original form
+- Up arrow: pitch the camera up
+- Down arrow: pitch the camera down
+- Left arrow: yaw the camera to the left
+- Right arrow: yaw the camera to the right
+- Left mouse button: Click and hold to rotate the cube by moving the mouse horizontally and vertically.
+
+
 
 ## Cleaning up
 To clean up any generated files, run the following command:

--- a/include/drawing.h
+++ b/include/drawing.h
@@ -15,4 +15,8 @@ void drawCube(const Cube &cube);
 
 void drawCubes();
 
+void drawText();
+
+void updateCamera();
+
 #endif

--- a/include/inputHandling.h
+++ b/include/inputHandling.h
@@ -11,4 +11,10 @@ void normalKeys(unsigned char key, int x, int y);
 
 void specialKeys(int key, int x, int y);
 
+void mouse(int button, int state, int x, int y);
+
+void motion(int x, int y);
+
+void passiveMotion(int x, int y);
+
 #endif

--- a/include/sharedVariables.h
+++ b/include/sharedVariables.h
@@ -2,6 +2,8 @@
 #define SHAREDVARIABLES_H
 
 #include <functional>
+#include <GL/glut.h>
+#include <string>
 
 #include "initializeCube.h"
 
@@ -14,5 +16,20 @@ extern const int LEFT;
 extern const int RIGHT;
 extern const int TOP;
 extern const int BOTTOM;
+
+// Initialize variables for camera position and orientation
+extern GLfloat cameraX;
+extern GLfloat cameraY;
+extern GLfloat cameraZ;
+extern GLfloat cameraYaw;
+extern GLfloat cameraPitch;
+extern GLfloat cameraRow;
+
+extern std::string text;
+
+// Initialize variables for mouse movement
+extern int lastMouseX;
+extern int lastMouseY;
+extern bool mouseDown;
 
 #endif

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -19,6 +19,9 @@ int main(int argc, char **argv)
     glutDisplayFunc(display);
     glutSpecialFunc(specialKeys);
     glutKeyboardFunc(normalKeys);
+    glutMouseFunc(mouse);
+    glutMotionFunc(motion);
+    glutPassiveMotionFunc(passiveMotion);
 
     // Enable depth testing to correctly display the 3D cube
     glEnable(GL_DEPTH_TEST);

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -5,6 +5,8 @@ void display()
     glClearColor(0, 0, 0, 1);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
+    glPushMatrix();
+
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     int w = glutGet(GLUT_WINDOW_WIDTH);
@@ -12,13 +14,14 @@ void display()
     gluPerspective(60, w / h, 0.1, 100);
 
     glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-    gluLookAt(5.0f, 5.0f, 5.0f,
-              0.00f, 0.00f, 0.00f,
-              0.00f, 1.00f, 0.00f);
-
+    
+    updateCamera();
+    
     drawCubes();
+
+    glPopMatrix();
+
+    drawText();
 
     glutSwapBuffers();
 }

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -68,3 +68,54 @@ void drawCubes()
         drawCube(cubes[i]);
     }
 }
+
+void drawText()
+{
+
+    // Push the current matrix onto the stack to save it
+    glPushMatrix();
+
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    int w = glutGet(GLUT_WINDOW_WIDTH);
+    int h = glutGet(GLUT_WINDOW_HEIGHT);
+    gluPerspective(60, w / h, 0.1, 100);
+    glMatrixMode(GL_MODELVIEW);
+    glLoadIdentity();
+
+    gluLookAt(cameraX, cameraY, cameraZ, // Camera position
+              0.0f, 0.0f, 0.0f,          // Look at position
+              0.0f, 1.0f, 0.0f);         // Up direction
+
+    glPushMatrix();
+
+    // Set the color of the text
+    glColor3f(1.0, 1.0, 1.0);
+
+    // Position the text in 3D space
+    glRasterPos4f(-2, 3.5, 0, 1);
+
+    // Draw the text
+    for (int i = 0; i < text.length(); i++)
+    {
+        glutBitmapCharacter(GLUT_BITMAP_HELVETICA_18, text[i]);
+    }
+
+    // Pop the matrix from the stack to restore it to its previous state
+    glPopMatrix();
+    glPopMatrix();
+}
+
+void updateCamera()
+{
+    // Set the camera's position
+    glLoadIdentity();
+    gluLookAt(cameraX, cameraY, cameraZ, // Camera position
+              0.0f, 0.0f, 0.0f,          // Look at position
+              0.0f, 1.0f, 0.0f);         // Up direction
+
+    // Rotate the camera based on its direction
+    glRotatef(cameraYaw, 0.0f, 1.0f, 0.0f);
+    glRotatef(cameraPitch, 1.0f, 0.0f, 0.0f);
+    glRotatef(cameraRow, 0.0f, 0.0f, 1.0f);
+}

--- a/src/inputHandling.cpp
+++ b/src/inputHandling.cpp
@@ -2,14 +2,22 @@
 
 void specialKeys(int key, int x, int y)
 {
-    if (key == GLUT_KEY_RIGHT)
-        moveSide(0, 1);
-    else if (key == GLUT_KEY_LEFT)
-        moveSide(1, 1);
-    else if (key == GLUT_KEY_UP)
-        moveSide(2, 1);
-    else if (key == GLUT_KEY_DOWN)
-        moveSide(3, 1);
+
+    switch (key)
+    {
+    case GLUT_KEY_UP:
+        cameraPitch -= 4.0f;
+        break;
+    case GLUT_KEY_DOWN:
+        cameraPitch += 4.0f;
+        break;
+    case GLUT_KEY_LEFT:
+        cameraYaw -= 4.0f;
+        break;
+    case GLUT_KEY_RIGHT:
+        cameraYaw += 4.0f;
+        break;
+    }
     glutPostRedisplay();
 }
 
@@ -68,5 +76,41 @@ void normalKeys(unsigned char key, int x, int y)
         moveSide(BOTTOM, -1);
     }
 
+    glutPostRedisplay();
+}
+
+void mouse(int button, int state, int x, int y)
+{
+    if (button == GLUT_LEFT_BUTTON)
+    {
+        if (state == GLUT_DOWN)
+        {
+            mouseDown = true;
+        }
+        else
+        {
+            mouseDown = false;
+        }
+    }
+}
+
+void motion(int x, int y)
+{
+
+    if (mouseDown)
+    {
+        cameraYaw += (lastMouseX - x) * 0.5f;
+        cameraPitch += (lastMouseY - y) * 0.5f;
+    }
+    lastMouseX = x;
+    lastMouseY = y;
+    text = std::to_string(x) + " " + std::to_string(y);
+    glutPostRedisplay();
+}
+
+void passiveMotion(int x, int y) {
+    lastMouseX = x;
+    lastMouseY = y;
+    text = std::to_string(x) + " " + std::to_string(y);
     glutPostRedisplay();
 }

--- a/src/sharedVariables.cpp
+++ b/src/sharedVariables.cpp
@@ -9,3 +9,19 @@ const int LEFT = 2;
 const int RIGHT = 3;
 const int TOP = 4;
 const int BOTTOM = 5;
+
+
+// Initialize variables for camera position and orientation
+GLfloat cameraX = 5.0f;
+GLfloat cameraY = 5.0f;
+GLfloat cameraZ = 5.0f;
+GLfloat cameraYaw = 0.0f;
+GLfloat cameraPitch = 0.0f;
+GLfloat cameraRow = 0.0f;
+
+std::string text = "0 0";
+
+// Initialize variables for mouse movement
+int lastMouseX = 0;
+int lastMouseY = 0;
+bool mouseDown = false;


### PR DESCRIPTION
Specifically, the pull request implements camera movement and cube rotation using keyboard and mouse inputs.

The Up arrow and Down arrow keys are used to pitch the camera up and down, respectively, while the Left arrow and Right arrow keys are used to yaw the camera to the left and right, respectively. This allows users to view the Rubik's Cube from different angles and perspectives.

Additionally, the Left mouse button can be clicked and held to rotate the cube by moving the mouse horizontally and vertically. This adds an interactive element to the program and allows users to manipulate the cube in real-time.

The pull request also includes a text element fixed in the window, although this is considered a minor addition.

